### PR TITLE
Changed keyReminder to use spaces, ignorekeys

### DIFF
--- a/src/Components/KeyReminder.js
+++ b/src/Components/KeyReminder.js
@@ -11,7 +11,7 @@ export class KeyReminder extends Component {
     }
     renderKeyHint = () => {
         if (this.props.showHint) {
-            const keys = Object.keys(this.props.currentLesson.lesson.keys).map(key => key[1]).join(',').replace(/,([^,]*)$/, ' or $1')
+            const keys = Object.keys(this.props.currentLesson.lesson.keys).map(key => key[1]).join(' ').replace(/\s([^\s]*)$/, ' or $1')
             return `${this.props.badKey} doesn't work for this lesson! try ${keys}`
         }
     }

--- a/src/redux/actions/grandMasterWizardKeyHandler.js
+++ b/src/redux/actions/grandMasterWizardKeyHandler.js
@@ -2,6 +2,14 @@ import store from   '../store'
 import keyHandler from './keys'
 import { showKeyHint } from './keyHint'
 
+
+const ignoreKeys = {
+    'Shift':true,
+    'Alt':true,
+    'Meta':true,
+    'Control':true
+}
+
 export default (e) => {
     // the grandMasterWizardKeyHandler decreeth:
     // let the keyboard do things!
@@ -13,6 +21,6 @@ export default (e) => {
     } else {
         //or don't.
         // display a warning/error/hint thing
-        store.dispatch(showKeyHint(key))
+        if (!ignoreKeys[key]) store.dispatch(showKeyHint(key))
     }
 }

--- a/src/redux/actions/keyHint.js
+++ b/src/redux/actions/keyHint.js
@@ -1,10 +1,17 @@
 import * as types from '../constants/keyHint'
 
 
-export const showKeyHint = (key) => ({
-    type: types.SHOW_KEY_HINT,
-    key
-})
+export const showKeyHint = (key) => {
+    return dispatch => {
+        if (key === ' ') {
+            key = 'Space'
+        }
+        dispatch({
+            type: types.SHOW_KEY_HINT,
+            key
+        })
+    }
+}
 
 export const hideKeyHint = () => ({
     type: types.HIDE_KEY_HINT


### PR DESCRIPTION
keyreminder now puts spaces between keys instead of commas, hopefully
less confusing. also, now the warning message will ignore specified keys
such as meta, control.. can add more.